### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/deako/manifest.json
+++ b/custom_components/deako/manifest.json
@@ -3,7 +3,7 @@
   "name": "Deako Smart Lighting",
   "documentation": "https://github.com/sebirdman/deako_hass_integration",
   "issue_tracker": "https://github.com/sebirdman/deako_hass_integration/issues",
-  "iot_class": "local_poll"
+  "iot_class": "local_poll",
   "dependencies": [],
   "config_flow": true,
   "codeowners": [


### PR DESCRIPTION
This error originated from a custom integration.

Logger: custom_components.hacs
Source: custom_components/hacs/repositories/integration.py:87 
Integration: HACS (documentation, issues) 
First occurred: 9:28:34 PM (2 occurrences) 
Last logged: 9:34:50 PM

<Integration sebirdman/deako_hass_integration> Could not read manifest.json [Expecting ',' delimiter: line 7 column 3 (char 242)]