### PR TITLE
Remediates the deprecated async_forward_entry_setup method

### DIFF
--- a/custom_components/deako/__init__.py
+++ b/custom_components/deako/__init__.py
@@ -46,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             hass.async_add_job(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
+                hass.config_entries.async_forward_entry_setups(entry, platform)
             )
 
     entry.add_update_listener(async_reload_entry)


### PR DESCRIPTION
Fixes the forwarding setup which was deprecated in 2025.6. Switches from `hass.config_entries.async_forward_entry_setup` to `hass.config_entries.async_forward_entry_setups`

More details on the deprecation and change at https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/